### PR TITLE
Make release-changelog workflow idempotent

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -43,7 +43,14 @@ jobs:
           echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
 
       - name: Build changelog and bump package version
+        shell: bash
         run: |
+          shopt -s nullglob
+          fragments=(changes.d/*.feature.md changes.d/*.bugfix.md changes.d/*.doc.md changes.d/*.misc.md)
+          if [[ ${#fragments[@]} -eq 0 ]]; then
+            echo "No changelog fragments left to build; release already applied. Skipping."
+            exit 0
+          fi
           sed -i "s/^version = .*/version = \"$RELEASE_VERSION\"/" pyproject.toml
           uv run towncrier build --yes --version "$RELEASE_VERSION"
 

--- a/changes.d/19.misc.md
+++ b/changes.d/19.misc.md
@@ -1,0 +1,1 @@
+Make the release-changelog workflow idempotent: skip the changelog build when no towncrier fragments remain, so re-triggered runs on a release branch no longer fail after the release commit has already been applied.


### PR DESCRIPTION
## Problem

`release-changelog.yml` triggers on every `synchronize` event of a `release/*` PR. The first run consumes the towncrier fragments and pushes the **Prepare release** commit — which is itself a push to the head branch, re-triggering `synchronize`. On that second run no fragments remain, so `towncrier build` exits non-zero and stamps the commit with a failed (red ✗) status, even though the release was applied correctly.

## Fix

Guard the build step: if no towncrier fragments are left in `changes.d/`, log and `exit 0` before running `towncrier build`. The downstream commit step already no-ops on an empty diff, so re-triggered runs now finish green.

## Validation

- Workflow-only change; verified the bash guard logic locally (nullglob fragment count).