### PR TITLE
fix: prevent integer underflow in netCDF diff field

### DIFF
--- a/changes.d/21.bugfix.md
+++ b/changes.d/21.bugfix.md
@@ -1,0 +1,1 @@
+Fix silent integer underflow when comparing integer-typed netCDF variables. Subtracting two unsigned/narrow integer fields wrapped around (e.g. `uint8` `10 - 12` became `254`), corrupting the reported min/max difference and relative error. Integer operands are now promoted to float before the difference is computed.

--- a/tests/test_ncdiff.py
+++ b/tests/test_ncdiff.py
@@ -168,6 +168,19 @@ def test_compare_variables_detects_mask_mismatch():
     assert result.mask_equal is False
 
 
+def test_compare_variables_does_not_wrap_around_on_unsigned_integers():
+    # Regression: uint8 subtraction wraps (10 - 12 -> 254), which used to
+    # corrupt the diff metrics. The diff must reflect the true signed values.
+    reference = make_data_array([10, 20, 30], dtype="uint8")
+    comparison = make_data_array([12, 18, 35], dtype="uint8")
+
+    result = compare_variables(reference, comparison, "counts", last_time_step=False)
+
+    assert result.min_diff == -5.0
+    assert result.max_diff == 2.0
+    assert result.relative_error == pytest.approx(2 / 12)
+
+
 def test_compare_variables_rejects_time_variables_when_last_time_step_is_enabled():
     reference = make_data_array(
         ["2024-01-01T00:00:00", "2024-01-02T00:00:00"],

--- a/xdiff/comparators/netcdf.py
+++ b/xdiff/comparators/netcdf.py
@@ -130,7 +130,15 @@ def compare_variables(
     reference_masked = ref_da.to_masked_array()
     comparison_masked = cmp_da.to_masked_array()
 
-    difference_field = reference_values - comparison_values
+    # Integer dtypes wrap around on subtraction (e.g. uint8: 10 - 12 -> 254),
+    # silently corrupting min/max/relative-error. Promote integer operands to
+    # float before subtracting; float and datetime/timedelta dtypes already
+    # subtract correctly and are left untouched (the time path relies on the
+    # resulting timedelta64).
+    if np.issubdtype(reference_values.dtype, np.integer):
+        difference_field = reference_values.astype(np.float64) - comparison_values.astype(np.float64)
+    else:
+        difference_field = reference_values - comparison_values
 
     if np.isnan(difference_field).all():
         raise AllNaN("All nan values found")


### PR DESCRIPTION
## Bug

Subtracting two integer-typed netCDF variables wrapped around, silently producing wrong diff metrics. Confirmed through the real `compare_variables` path:

```
uint8 ref=[10,20,30], cmp=[12,18,35]
before:  min_diff=2   max_diff=254  rel_err=21.17   ❌
after:   min_diff=-5  max_diff=2    rel_err=0.167   ✅
```

`10 - 12` underflows to `254` in `uint8`. This affects any integer variable — flags, counts, integer coordinates/dims. Float variables were never affected (xarray decodes packed data to float on open), which is why it went unnoticed.

## Fix

Promote integer operands to `float64` before computing the difference:

```python
if np.issubdtype(reference_values.dtype, np.integer):
    difference_field = reference_values.astype(np.float64) - comparison_values.astype(np.float64)
else:
    difference_field = reference_values - comparison_values
```

Float and datetime/timedelta dtypes are left untouched — the time path deliberately relies on the resulting `timedelta64`.

## Tests

- Adds `test_compare_variables_does_not_wrap_around_on_unsigned_integers` (the uint8 repro above).
- Full suite: 72 passed. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)