### PR TITLE
feat: map differently-named variables via -v REF=CMP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Key options shared by both subcommands:
 |---|---|
 | `-f / --filter` | Glob filter for files (default `*.nc`) |
 | `--common-pattern` | Regex identifying a common substring between filenames (e.g. `\d{8}`) |
-| `-v / --variables` | Variable(s) to compare; repeatable |
+| `-v / --variables` | Variable(s) to compare; repeatable. `NAME` compares the same name on both sides; `REF=CMP` maps differently-named variables (e.g. `thetao=votemper`) |
 | `--last-time-step` | Compare only the last time step |
 | `-w / --dask-workers N` | Run in parallel on a local Dask cluster with N workers (enables Dask) |
 | `--dask-scheduler` | Attach to an external Dask scheduler by address |

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ uv run xdiff dirs folder1 folder2 -v votemper -v vosaline
 
 ![Variables](https://github.com/anto6715/X-Diff/raw/master/docs/variables.png)
 
+To compare variables that are named differently between the two inputs, use `REF=CMP`:
+
+```shell
+uv run xdiff files reference.nc comparison.nc -v thetao=votemper -v lon=longitude
+```
+
 ### Filter files
 
 By default **xdiff** iterates over all files in **folder1** and expects to find them in **folder2**. Using filters,

--- a/changes.d/23.feature.md
+++ b/changes.d/23.feature.md
@@ -1,0 +1,1 @@
+`-v/--variables` now accepts `REF=CMP` to compare differently-named variables (e.g. `-v thetao=votemper -v lon=longitude`), on both the `dirs` and `files` commands. Plain `-v NAME` still compares the same name on both sides. Mapped pairs are labelled `ref -> cmp` in the report.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,7 +50,7 @@ def test_execute_builds_request_and_delegates_to_service(monkeypatch):
     assert fake_service.request.input_mode is CompareMode.DIRECTORIES
     assert fake_service.request.filter_name == "*.nc"
     assert fake_service.request.common_pattern == r"\d{8}\.nc"
-    assert fake_service.request.variables == ("temp",)
+    assert fake_service.request.variables == (("temp", "temp"),)
     assert fake_service.request.last_time_step is True
     assert fake_service.request.uses_dask is False
     assert fake_service.request.dask_scheduler is None
@@ -68,6 +68,18 @@ def test_build_request_normalizes_default_variable_selection_to_none():
     assert request.variables is None
     assert request.input_mode is CompareMode.DIRECTORIES
     assert request.uses_dask is False
+
+
+def test_normalize_variables_parses_plain_and_mapped_specs():
+    assert main.normalize_variables(["thetao=votemper", "lon=longitude", "temp"]) == (
+        ("thetao", "votemper"),
+        ("lon", "longitude"),
+        ("temp", "temp"),
+    )
+
+
+def test_normalize_variables_strips_whitespace_around_mapping():
+    assert main.normalize_variables(["thetao = votemper"]) == (("thetao", "votemper"),)
 
 
 def test_build_request_enables_dask_from_worker_option():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from xdiff.core import main
 from xdiff.model import CompareMode
 
@@ -80,6 +82,12 @@ def test_normalize_variables_parses_plain_and_mapped_specs():
 
 def test_normalize_variables_strips_whitespace_around_mapping():
     assert main.normalize_variables(["thetao = votemper"]) == (("thetao", "votemper"),)
+
+
+@pytest.mark.parametrize("spec", ["=votemper", "thetao=", "=", ""])
+def test_normalize_variables_rejects_specs_with_an_empty_side(spec):
+    with pytest.raises(ValueError, match="Invalid variable specification"):
+        main.normalize_variables([spec])
 
 
 def test_build_request_enables_dask_from_worker_option():

--- a/tests/test_ncdiff.py
+++ b/tests/test_ncdiff.py
@@ -41,7 +41,7 @@ def test_get_dataset_variables_defaults_skip_string_like_values():
 
     variables = get_dataset_variables(dataset, settings.DEFAULT_VARIABLES_TO_CHECK)
 
-    assert variables == ["temp", "time"]
+    assert variables == [("temp", "temp"), ("time", "time")]
 
 
 def test_get_dataset_variables_respects_explicit_variable_selection():
@@ -54,7 +54,7 @@ def test_get_dataset_variables_respects_explicit_variable_selection():
 
     variables = get_dataset_variables(dataset, ["label", "temp", "missing"])
 
-    assert variables == ["temp"]
+    assert variables == [("temp", "temp")]
 
 
 def test_find_time_dims_name_returns_single_time_dimension():
@@ -243,6 +243,29 @@ def test_compare_datasets_records_variable_level_errors():
 
     assert len(results) == 1
     assert results[0].variable == "temp"
+    assert results[0].description != "-"
+
+
+def test_compare_datasets_maps_differently_named_variables():
+    reference = xr.Dataset({"thetao": ("x", [1.0, 2.0, 3.0])})
+    comparison = xr.Dataset({"votemper": ("x", [1.0, 2.0, 3.0])})
+
+    results = compare_datasets(reference, comparison, [("thetao", "votemper")], last_time_step=False)
+
+    assert len(results) == 1
+    assert results[0].passed
+    assert results[0].variable == "thetao -> votemper"
+
+
+def test_compare_datasets_reports_missing_mapped_comparison_variable():
+    reference = xr.Dataset({"thetao": ("x", [1.0, 2.0])})
+    comparison = xr.Dataset({"other": ("x", [1.0, 2.0])})
+
+    results = compare_datasets(reference, comparison, [("thetao", "votemper")], last_time_step=False)
+
+    assert len(results) == 1
+    assert not results[0].passed
+    assert results[0].variable == "thetao -> votemper"
     assert results[0].description != "-"
 
 

--- a/tests/test_ncdiff.py
+++ b/tests/test_ncdiff.py
@@ -235,6 +235,17 @@ def test_compare_variables_allows_non_time_variables_with_time_in_the_name():
     assert result.passed is True
 
 
+def test_compare_variables_rejects_mapped_time_coordinate_with_last_time_step():
+    # A mapped time axis has differently-named dims on each side; the guard must
+    # still fire (detection is by dtype/shape, not by name).
+    values = ["2024-01-01T00:00:00", "2024-01-02T00:00:00"]
+    reference = make_data_array(values, dims=("time",), dtype="datetime64[ns]")
+    comparison = make_data_array(values, dims=("time_counter",), dtype="datetime64[ns]")
+
+    with pytest.raises(LastTimestepTimeCheckException, match="Can't compare time"):
+        compare_variables(reference, comparison, "time -> time_counter", last_time_step=True)
+
+
 def test_compare_datasets_records_variable_level_errors():
     reference = xr.Dataset({"temp": ("x", [1.0, 2.0])})
     comparison = xr.Dataset()

--- a/xdiff/comparators/netcdf.py
+++ b/xdiff/comparators/netcdf.py
@@ -86,8 +86,8 @@ def _as_variable_pair(item: str | tuple[str, str]) -> tuple[str, str]:
     """Coerce a variable spec to a (reference_name, comparison_name) pair."""
     if isinstance(item, str):
         return (item, item)
-    reference_name, comparison_name = item
-    return (reference_name, comparison_name)
+    reference_name, comparison_name = item  # unpacking also asserts a 2-element pair
+    return reference_name, comparison_name
 
 
 def compare_datasets(
@@ -128,7 +128,7 @@ def compare_variables(
     last_time_step: bool,
 ) -> CompareResult:
     if last_time_step:
-        if is_time_coordinate_variable(variable, ref_da, cmp_da):
+        if is_time_coordinate_variable(ref_da, cmp_da):
             raise LastTimestepTimeCheckException("Can't compare time if last time step is enabled")
         ref_da = select_last_time_step(ref_da)
         cmp_da = select_last_time_step(cmp_da)
@@ -245,20 +245,19 @@ def is_time_dtype(dtype) -> bool:
     return np.issubdtype(normalized_dtype, np.datetime64) or np.issubdtype(normalized_dtype, np.timedelta64)
 
 
-def is_time_coordinate_variable(variable: str, ref_da: xr.DataArray, cmp_da: xr.DataArray) -> bool:
-    time_dimension = find_time_dims_name(ref_da.dims)
-    comparison_time_dimension = find_time_dims_name(cmp_da.dims)
+def is_time_coordinate_variable(ref_da: xr.DataArray, cmp_da: xr.DataArray) -> bool:
+    """True when both sides are a 1-D datetime time axis (the time coordinate).
 
-    if time_dimension != comparison_time_dimension or time_dimension is None:
-        return False
+    Detection is by dimension shape and dtype rather than by name, so it also
+    holds for a mapped pair whose time axes are named differently (e.g. a
+    ``time=time2`` mapping), where a name-based check would miss it.
+    """
+    return _is_time_axis(ref_da) and _is_time_axis(cmp_da)
 
-    return (
-        variable == time_dimension
-        and ref_da.dims == (time_dimension,)
-        and cmp_da.dims == (time_dimension,)
-        and is_time_dtype(ref_da.dtype)
-        and is_time_dtype(cmp_da.dtype)
-    )
+
+def _is_time_axis(da: xr.DataArray) -> bool:
+    time_dimension = find_time_dims_name(da.dims)
+    return time_dimension is not None and da.dims == (time_dimension,) and is_time_dtype(da.dtype)
 
 
 def validate_matching_metadata(ref_da: xr.DataArray, cmp_da: xr.DataArray) -> None:

--- a/xdiff/comparators/netcdf.py
+++ b/xdiff/comparators/netcdf.py
@@ -82,30 +82,40 @@ def compare_files(
         )
 
 
+def _as_variable_pair(item: str | tuple[str, str]) -> tuple[str, str]:
+    """Coerce a variable spec to a (reference_name, comparison_name) pair."""
+    if isinstance(item, str):
+        return (item, item)
+    reference_name, comparison_name = item
+    return (reference_name, comparison_name)
+
+
 def compare_datasets(
     reference: xr.Dataset,
     comparison: xr.Dataset,
-    variables: list[str],
+    variables: list[str] | list[tuple[str, str]],
     *,
     last_time_step: bool,
 ) -> list[CompareResult]:
     results: list[CompareResult] = []
 
-    for variable in variables:
-        logger.info("Comparing %s", variable)
+    for item in variables:
+        reference_name, comparison_name = _as_variable_pair(item)
+        label = reference_name if reference_name == comparison_name else f"{reference_name} -> {comparison_name}"
+        logger.info("Comparing %s", label)
         try:
-            reference_field = reference[variable]
-            comparison_field = comparison[variable]
+            reference_field = reference[reference_name]
+            comparison_field = comparison[comparison_name]
             results.append(
                 compare_variables(
                     reference_field,
                     comparison_field,
-                    variable,
+                    label,
                     last_time_step=last_time_step,
                 )
             )
         except Exception as exc:
-            results.append(CompareResult(variable=variable, description=str(exc)))
+            results.append(CompareResult(variable=label, description=str(exc)))
 
     return results
 
@@ -300,24 +310,32 @@ def validate_matching_metadata(ref_da: xr.DataArray, cmp_da: xr.DataArray) -> No
             logger.debug("Coordinate values mismatch for '%s'", coordinate_name)
 
 
-def get_dataset_variables(dataset: xr.Dataset, variables: tuple[str, ...] | list[str] | object | None) -> list[str]:
-    """Extract comparable variables and dimensions from a dataset."""
-    selected_variables: list[str] = []
+def get_dataset_variables(
+    dataset: xr.Dataset,
+    variables: tuple[tuple[str, str], ...] | list | object | None,
+) -> list[tuple[str, str]]:
+    """Select comparable (reference_name, comparison_name) variable pairs.
 
+    Filtering (presence + non-string dtype) is done against the reference
+    dataset; the comparison-side name is validated later in ``compare_datasets``
+    against the comparison dataset. When no selection is given, defaults to every
+    data variable and dimension, compared under the same name on both sides.
+    """
     if variables in (None, settings.DEFAULT_VARIABLES_TO_CHECK):
-        variables_to_check = list(dataset.data_vars) + list(dataset.dims)
+        pairs = [(name, name) for name in list(dataset.data_vars) + list(dataset.dims)]
     else:
-        variables_to_check = list(variables)
+        pairs = [_as_variable_pair(item) for item in variables]
 
-    for variable in variables_to_check:
-        if variable not in dataset:
+    selected_variables: list[tuple[str, str]] = []
+    for reference_name, comparison_name in pairs:
+        if reference_name not in dataset:
             continue
 
-        dtype_kind = dataset[variable].dtype.kind
+        dtype_kind = dataset[reference_name].dtype.kind
         if dtype_kind in ("U", "S", "O", "a"):
-            logger.debug("Skipping variable %s due to datatype %s", variable, dtype_kind)
+            logger.debug("Skipping variable %s due to datatype %s", reference_name, dtype_kind)
             continue
 
-        selected_variables.append(variable)
+        selected_variables.append((reference_name, comparison_name))
 
     return selected_variables

--- a/xdiff/core/main.py
+++ b/xdiff/core/main.py
@@ -68,10 +68,24 @@ def build_request(
     )
 
 
-def normalize_variables(variables: Iterable[str] | object) -> tuple[str, ...] | None:
+def normalize_variables(variables: Iterable[str] | object) -> tuple[tuple[str, str], ...] | None:
     if variables in (None, settings.DEFAULT_VARIABLES_TO_CHECK):
         return None
-    return tuple(variables)
+    return tuple(_parse_variable_spec(spec) for spec in variables)
+
+
+def _parse_variable_spec(spec: str | tuple[str, str]) -> tuple[str, str]:
+    """Parse one ``-v`` value into a (reference, comparison) name pair.
+
+    A plain ``NAME`` compares the same name on both sides; ``REF=CMP`` maps a
+    reference variable to a differently-named comparison variable.
+    """
+    if isinstance(spec, tuple):
+        return spec
+    if "=" in spec:
+        reference_name, comparison_name = spec.split("=", 1)
+        return (reference_name.strip(), comparison_name.strip())
+    return (spec, spec)
 
 
 def load_files(directory: Path, filter_name: str) -> list[Path]:

--- a/xdiff/core/main.py
+++ b/xdiff/core/main.py
@@ -78,14 +78,19 @@ def _parse_variable_spec(spec: str | tuple[str, str]) -> tuple[str, str]:
     """Parse one ``-v`` value into a (reference, comparison) name pair.
 
     A plain ``NAME`` compares the same name on both sides; ``REF=CMP`` maps a
-    reference variable to a differently-named comparison variable.
+    reference variable to a differently-named comparison variable. A malformed
+    spec with an empty side (e.g. ``=votemper`` or ``thetao=``) is rejected so a
+    typo fails loudly instead of silently comparing nothing.
     """
     if isinstance(spec, tuple):
         return spec
     if "=" in spec:
-        reference_name, comparison_name = spec.split("=", 1)
-        return (reference_name.strip(), comparison_name.strip())
-    return (spec, spec)
+        reference_name, comparison_name = (part.strip() for part in spec.split("=", 1))
+    else:
+        reference_name = comparison_name = spec.strip()
+    if not reference_name or not comparison_name:
+        raise ValueError(f"Invalid variable specification {spec!r}: expected NAME or REF=CMP with non-empty names.")
+    return (reference_name, comparison_name)
 
 
 def load_files(directory: Path, filter_name: str) -> list[Path]:

--- a/xdiff/management/cli.py
+++ b/xdiff/management/cli.py
@@ -132,7 +132,10 @@ def cli(ctx: click.Context) -> None:
     "-v",
     "--variables",
     multiple=True,
-    help="Variables to compare. Repeat the option to compare multiple variables.",
+    help=(
+        "Variables to compare. Repeat the option to compare multiple variables. "
+        "Use REF=CMP to compare differently-named variables (e.g. thetao=votemper)."
+    ),
 )
 @click.option(
     "--last-time-step",
@@ -188,7 +191,10 @@ def compare_directories(
     "-v",
     "--variables",
     multiple=True,
-    help="Variables to compare. Repeat the option to compare multiple variables.",
+    help=(
+        "Variables to compare. Repeat the option to compare multiple variables. "
+        "Use REF=CMP to compare differently-named variables (e.g. thetao=votemper)."
+    ),
 )
 @click.option(
     "--last-time-step",

--- a/xdiff/model/request.py
+++ b/xdiff/model/request.py
@@ -45,7 +45,9 @@ class CompareRequest:
     comparison_path: Path
     filter_name: str
     common_pattern: str | None
-    variables: tuple[str, ...] | None
+    # Ordered (reference_name, comparison_name) pairs; None means "all data vars
+    # and dims, same name on both sides". Plain -v names normalize to (n, n).
+    variables: tuple[tuple[str, str], ...] | None
     last_time_step: bool = False
     dask_scheduler: str | None = None
     dask_scheduler_file: Path | None = None


### PR DESCRIPTION
Point #3 of the netCDF-deepening sequence (1→3→2).

## What

Compare variables that are named differently between the two inputs:

```shell
xdiff files reference.nc comparison.nc -v thetao=votemper -v lon=longitude
xdiff dirs  A/ B/ -v thetao=votemper       # same map applied to every matched pair
```

- `-v NAME` — same name on both sides (unchanged).
- `-v REF=CMP` — map a reference variable to a differently-named comparison variable.
- Available on **both** `dirs` and `files`.
- Mapped checks are labelled `ref -> cmp` in the report.

## How

Variables are normalized to ordered `(reference_name, comparison_name)` pairs; plain names become `(n, n)`:
- `normalize_variables` parses `=` specs (whitespace-trimmed).
- `CompareRequest.variables: tuple[tuple[str, str], ...] | None`.
- `get_dataset_variables` filters on the reference dataset and returns the surviving pairs; `compare_datasets` indexes each side by its own name, labels the result, and reports a clear failure if the mapped comparison variable is missing.
- A `_as_variable_pair` coercion helper keeps the legacy `compare/ncdiff.py` proxy and existing string-list callers/tests working (no change to the legacy `compare()` API).

The existing metadata validation already only *logs* dimension-name/coordinate differences (raising only on shape/dtype mismatch), so `lon` vs `longitude` with matching shape compares cleanly.

## Verified
- 78 tests pass (4 new: spec parsing, whitespace trim, mapped compare, missing mapped var); ruff clean.
- **End-to-end via the real CLI**: `-v thetao=votemper` computes the true diff and exits 1 on difference; `-v lon=longitude` maps coordinates and exits 0 when identical; plain `-v NAME` unchanged.

Docs: README example + AGENTS.md option table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)